### PR TITLE
[SC-22963] Add arguments to add custom env vars to 'commands' when using 'rez pip'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ wiki/out
 LATEST_CHANGELOG.md
 __pycache__
 .git-commit-template
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file. For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/

--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -8,6 +8,11 @@ Install a pip-compatible python package, and its dependencies, as rez packages.
 from __future__ import print_function
 from argparse import REMAINDER
 import logging
+import json
+
+
+def parse_dict(value: str):
+    return json.loads(value.replace("\'", "\""))
 
 
 def setup_parser(parser, completions=False):
@@ -33,6 +38,16 @@ def setup_parser(parser, completions=False):
     parser.add_argument(
         "PACKAGE",
         help="package to install or archive/url to install from")
+    parser.add_argument(
+        "-cev", "--commands-env-vars", type=parse_dict,
+        help="Add new env vars to the 'commands' function of the automatically "
+        "created 'package.py' file"
+    )
+    parser.add_argument(
+        "-bcev", "--building-commands-env-vars", type=parse_dict,
+        help="Add new env vars to the 'commands' function of the automatically "
+        "created 'package.py' file at build time"
+    )
     parser.add_argument(
         "-e", "--extra", nargs=REMAINDER,
         help="extra args passthrough to pip install (overrides pre-configured args if specified)"
@@ -70,4 +85,6 @@ def command(opts, parser, extra_arg_groups=None):
         python_version=opts.py_ver,
         release=opts.release,
         prefix=opts.prefix,
+        commands_env_vars=opts.commands_env_vars,
+        building_commands_env_vars=opts.building_commands_env_vars,
         extra_args=opts.extra)


### PR DESCRIPTION
As @MihaiMart let me know, to build the [`vfx_nuke_raw_pred_transform`](https://github.com/Metaphysic-ai/vfx_nuke_raw_pred_transform) package a [`NUMPY_INCLUDE_DIR`](https://github.com/Metaphysic-ai/vfx_nuke_raw_pred_transform/blob/405af531ac2cae1f2f352c0d5d25a40e91f27e95/CMakeLists.txt#L58) env var is required, only at build time.

So, we need to add this env var but only when `numpy` is used [to build another package](https://rez.readthedocs.io/en/stable/building_packages.html#package-communication), as is the case with `vfx_nuke_raw_pred_transform`.

The problem is that we don't have a `package.py` file specified for `numpy`. We just install it using `rez pip` as we do for other 3rd party libraries.

So, the suggested solution is to add the following new arguments when calling `rez pip`:
```
 -cev COMMANDS_ENV_VARS [COMMANDS_ENV_VARS ...], --commands-env-vars COMMANDS_ENV_VARS [COMMANDS_ENV_VARS ...]
                        Add new env vars to the 'commands' function of the
                        automatically created 'package.py' file
 -bcev BUILDING_COMMANDS_ENV_VARS [BUILDING_COMMANDS_ENV_VARS ...], --building-commands-env-vars BUILDING_COMMANDS_ENV_VARS [BUILDING_COMMANDS_ENV_VARS ...]
                        Add new env vars to the 'commands' function of the
                        automatically created 'package.py' file at build time
```

This way, we could re-install `numpy` running:

```
rez pip --install --building-commands-env-vars '{"NUMPY_INCLUDE_DIR": "/usr/local/lib/python3.9/site-packages/numpy/core/include"}' numpy
```

and then the `commands` function in the automatically generated `package.py` file will have:

```
def commands():
    if building:
        env.NUMPY_INCLUDE_DIR.set('/usr/local/lib/python3.9/site-packages/numpy/core/include')
    
    env.PYTHONPATH.append('{root}/python')
    env.PATH.append('{root}/bin')
```